### PR TITLE
EDDN integration rewrite

### DIFF
--- a/Journal-Limpet.Shared/EDDN/ApproachSettlementEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/ApproachSettlementEvents.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class ApproachSettlement : EventBase
+    {
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/approachsettlement/1";
+
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+
+        public enum AllowedEvents
+        {
+            ApproachSettlement
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            StarSystem,
+            StarPos,
+            SystemAddress,
+            Name,
+            BodyID,
+            BodyName,
+            Latitude,
+            Longitude
+        }
+
+        public enum RemoveProperties
+        {
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/CodexEntry.cs
+++ b/Journal-Limpet.Shared/EDDN/CodexEntry.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class CodexEntry : EventBase
+    {
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/codexentry/1";
+
+        public enum AllowedEvents
+        {
+            CodexEntry
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            System,
+            StarPos,
+            SystemAddress,
+            EntryID
+        }
+
+        public enum RemoveProperties
+        {
+            IsNewEntry,
+            NewTraitsDiscovered,
+            BodyID,
+            BodyName
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/EventBase.cs
+++ b/Journal-Limpet.Shared/EDDN/EventBase.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public abstract class EventBase
+    {
+        public abstract string SchemaRef();
+
+        public abstract Type GetAllowedEvents();
+        public abstract Type GetRequiredProperties();
+        public abstract Type GetRemoveProperties();
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/FSSAllBodiesFoundEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/FSSAllBodiesFoundEvents.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class FSSAllBodiesFound : EventBase
+    {
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/fssallbodiesfound/1";
+
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+        public enum AllowedEvents
+        {
+            FSSAllBodiesFound
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            SystemName,
+            StarPos,
+            SystemAddress,
+            Count
+        }
+
+        public enum RemoveProperties
+        {
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/FSSBodySignalsEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/FSSBodySignalsEvents.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class FSSBodySignals : EventBase
+    {
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/fssbodysignals/1";
+
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+        public enum AllowedEvents
+        {
+            FSSBodySignals
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            StarSystem,
+            StarPos,
+            SystemAddress,
+            BodyID,
+            Signals
+        }
+
+        public enum RemoveProperties
+        {
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/FSSDiscoveryScanEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/FSSDiscoveryScanEvents.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class FSSDiscoveryScan : EventBase
+    {
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/fssdiscoveryscan/1";
+
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+        public enum AllowedEvents
+        {
+            FSSDiscoveryScan
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            SystemName,
+            StarPos,
+            SystemAddress,
+            BodyCount,
+            NonBodyCount
+        }
+
+        public enum RemoveProperties
+        {
+            Progress
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/JournalEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/JournalEvents.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class Journal : EventBase
+    {
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/journal/1";
+
+        public enum AllowedEvents
+        {
+            Docked,
+            FSDJump,
+            Scan,
+            Location,
+            SAASignalsFound,
+            CarrierJump
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            StarSystem,
+            StarPos,
+            SystemAddress
+        }
+
+        public enum RemoveProperties
+        {
+            Wanted,
+            ActiveFine,
+            CockpitBreach,
+            BoostUsed,
+            FuelLevel,
+            FuelUsed,
+            JumpDist,
+            Latitude,
+            Longitude,
+            HappiestSystem,
+            HomeSystem,
+            MyReputation,
+            SquadronFaction,
+            IsNewEntry,
+            NewTraitsDiscovered,
+            Traits,
+            VoucherAmount
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/NavBeaconScanEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/NavBeaconScanEvents.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class NavBeaconScan : EventBase
+    {
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/navbeaconscan/1";
+
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+        public enum AllowedEvents
+        {
+            NavBeaconScan
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            StarSystem,
+            StarPos,
+            SystemAddress,
+            NumBodies
+        }
+
+        public enum RemoveProperties
+        {
+        }
+    }
+}

--- a/Journal-Limpet.Shared/EDDN/ScanBaryCentreEvents.cs
+++ b/Journal-Limpet.Shared/EDDN/ScanBaryCentreEvents.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Journal_Limpet.Shared.EDDN
+{
+    public class ScanBaryCentre : EventBase
+    {
+        public override string SchemaRef() => "https://eddn.edcd.io/schemas/scanbarycentre/1";
+
+        public override Type GetAllowedEvents() => typeof(AllowedEvents);
+
+        public override Type GetRemoveProperties() => typeof(RemoveProperties);
+
+        public override Type GetRequiredProperties() => typeof(RequiredProperties);
+
+        public enum AllowedEvents
+        {
+            ScanBaryCentre
+        }
+
+        public enum RequiredProperties
+        {
+            timestamp,
+            @event,
+            StarSystem,
+            StarPos,
+            SystemAddress,
+            BodyID
+        }
+
+        public enum RemoveProperties
+        {
+        }
+    }
+}

--- a/Journal-Limpet.Shared/GameStateChanger.cs
+++ b/Journal-Limpet.Shared/GameStateChanger.cs
@@ -193,7 +193,7 @@ namespace Journal_Limpet.Shared
                 }
             }
 
-            if (new[] { "SAASignalsFound", "SAAScanComplete", "Scan", }.Contains(eventName))
+            if (new[] { "FSSBodySignals", "SAASignalsFound", "SAAScanComplete", "Scan", }.Contains(eventName))
             {
                 SetSystemAddress(gameState, elementAsDictionary, false);
                 SetStarSystem(gameState, elementAsDictionary, false);

--- a/Journal-Limpet.Shared/Journal-Limpet.Shared.csproj
+++ b/Journal-Limpet.Shared/Journal-Limpet.Shared.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Journal_Limpet.Shared</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Minio" Version="3.1.13" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="SendGrid" Version="9.22.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+    <PackageReference Include="SendGrid" Version="9.28.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
   </ItemGroup>
 
 </Project>

--- a/Journal-Limpet.Tests/Journal-Limpet.Tests.csproj
+++ b/Journal-Limpet.Tests/Journal-Limpet.Tests.csproj
@@ -1,17 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Journal_Limpet.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Journal-Limpet/Journal-Limpet.csproj
+++ b/Journal-Limpet/Journal-Limpet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Journal_Limpet</RootNamespace>
   </PropertyGroup>
 
@@ -26,21 +26,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.18" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.29" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
-    <PackageReference Include="HangFire.Redis.StackExchange" Version="1.8.4" />
-    <PackageReference Include="Hangfire.SqlServer" Version="1.7.18" />
-    <PackageReference Include="Markdig" Version="0.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.1.10" />
+    <PackageReference Include="HangFire.Redis.StackExchange" Version="1.8.5" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.7.29" />
+    <PackageReference Include="Markdig" Version="0.30.2" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.5" />
     <PackageReference Include="Minio" Version="3.1.13" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.36.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.8.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="SendGrid" Version="9.22.0" />
-    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.17" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="SendGrid" Version="9.28.0" />
+    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.32" />
+    <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />


### PR DESCRIPTION
To support even more schemas available in EDDN, I rewrote the integration to make it easier for me to build support for schemas later on.

So far I've added:
- [ApproachSettlement](https://github.com/EDCD/EDDN/blob/live/schemas/approachsettlement-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/approachsettlement-README.md))
- [CodexEntry](https://github.com/EDCD/EDDN/blob/live/schemas/codexentry-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/codexentry-README.md))
- [FSSAllBodiesFound](https://github.com/EDCD/EDDN/blob/live/schemas/fssallbodiesfound-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/fssallbodiesfound-README.md))
- [FSSBodySignals](https://github.com/EDCD/EDDN/blob/live/schemas/fssbodysignals-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/fssbodysignals-README.md))
- [FSSDiscoveryScan](https://github.com/EDCD/EDDN/blob/live/schemas/fssdiscoveryscan-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/fssdiscoveryscan-README.md))
- [Journal](https://github.com/EDCD/EDDN/blob/live/schemas/journal-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/journal-README.md))
- [NavBeaconScan](https://github.com/EDCD/EDDN/blob/live/schemas/navbeaconscan-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/navbeaconscan-README.md))
- [ScanBaryCentre](https://github.com/EDCD/EDDN/blob/live/schemas/scanbarycentre-v1.0.json) ([Readme](https://github.com/EDCD/EDDN/blob/live/schemas/scanbarycentre-README.md))

I have skipped adding support for:
- Market
- NavRoute
- Outfitting
- Shipyard

As they require access to local files, or CAPI Access at the correct moment.

## Other changes

- Added `FSSBodySignals` to GameStateChanger, to keep track of system.
- Updated project to .NET 6, along with some dependencies